### PR TITLE
Switch workflow event to pull_request_target and introduce labeler workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,12 +4,15 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
+    types:
+      - labeled
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -83,6 +86,7 @@ jobs:
   #         rm -rf ${{ env.DURABLE_FUNCTIONAPP_PACKAGE_PATH }}
   test:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,15 @@
+name: Labeler
+on:
+  pull_request_target:
+    branches:
+      - main
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        github_token: ${{github.token}}
+        labels: "needs-ok-to-test"


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

fixes https://github.com/SAME-Project/same-project/issues/61

- Update workflow event trigger to `pull_request_target` to give write access `GITHUB_TOKEN` to forked repos
- Add labeler workflow to add `needs-ok-to-test` label for all PRs which requires vetting and label `ok-to-test` to allow build/test workflow to trigger

Even though the labeler workflow also is given `write` access to label the pull request, I think that's okay based on the [blog post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) which mentions that it's the explicit checkout of an untrusted PR that's the dangerous practice:

```
TL;DR: Combining pull_request_target workflow trigger with an explicit checkout of an untrusted PR is a dangerous practice that may lead to repository compromise.
```

I also think that someone with access needs to create the two labels (`needs-ok-to-test` and `ok-to-test`) manually before the labels can be used in the workflow.
