### PR TITLE
Add tests for broken notebook patterns in kubeflow backend

### DIFF
--- a/sameproject/backends/kubeflow/deploy.py
+++ b/sameproject/backends/kubeflow/deploy.py
@@ -18,4 +18,4 @@ def deploy_function(compiled_path: Path, root_module_name: str):
 
         # Only works with the 'kubeflow' namespace for now
         kfp_client = kfp.Client()
-        kfp_client.create_run_from_pipeline_func(root_module.root, arguments={})  # type: ignore noqa
+        return kfp_client.create_run_from_pipeline_func(root_module.root, arguments={})  # type: ignore noqa

--- a/sameproject/backends/kubeflow/render.py
+++ b/sameproject/backends/kubeflow/render.py
@@ -15,7 +15,6 @@ kubeflow_root_template = "kubeflow/root.jinja"
 kubeflow_step_template = "kubeflow/step.jinja"
 
 
-
 def render_function(compile_path: str, steps: list, same_config: dict) -> Tuple[Path, str]:
     """Renders the notebook into a root file and a series of step files according to the target requirements. Returns an absolute path to the root file for deployment."""
     sourceDir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/sameproject/program/compile/notebook_processing.py
+++ b/sameproject/program/compile/notebook_processing.py
@@ -82,25 +82,25 @@ def get_steps(notebook_dict: dict) -> dict:
     all_code += "\n" + this_step.code
     return_steps[this_step.name] = this_step
 
-    #     magic_lines = []
-    #     for i, line in enumerate(all_code.split("\n")):
-    #         if jupytext.magics.is_magic(line, "python"):
-    #             magic_lines.append(f"line {i}: {line}")
+    magic_lines = []
+    for i, line in enumerate(all_code.split("\n")):
+        if jupytext.magics.is_magic(line, "python"):
+            magic_lines.append(f"line {i}: {line}")
 
-    #     if len(magic_lines) > 0:
-    #         magic_lines_string = "\n".join(magic_lines)
-    #         logging.fatal(
-    #             f"""
-    # We cannot continue because the following lines cannot be converted into standard python code. Please correct them:
-    # { magic_lines_string }"""
-    #         )
-    #         # After logging.error, what's pythonic? Raising? I'm doing it, but curious.
-    #         raise SyntaxError
+    if len(magic_lines) > 0:
+        magic_lines_string = "\n".join(magic_lines)
+        logging.fatal(
+            f"""
+We cannot continue because the following lines cannot be converted into standard python code. Please correct them:
+{ magic_lines_string }"""
+        )
+        # After logging.error, what's pythonic? Raising? I'm doing it, but curious.
+        raise SyntaxError
 
-    #     for k in return_steps:
-    #         # If we want to do it just by code block, uncomment the below
-    #         # return_steps[k].packages_to_install = parse_code_block_for_imports(return_steps[k].code)
-    #         return_steps[k].packages_to_install = parse_code_block_for_imports(all_code)
+    for k in return_steps:
+        # If we want to do it just by code block, uncomment the below
+        # return_steps[k].packages_to_install = parse_code_block_for_imports(return_steps[k].code)
+        return_steps[k].packages_to_install = parse_code_block_for_imports(all_code)
 
     return return_steps
 

--- a/test/backends/test_kubeflow_backend.py
+++ b/test/backends/test_kubeflow_backend.py
@@ -1,0 +1,51 @@
+from sameproject.program.compile import notebook_processing as nbproc
+from sameproject.backends.executor import deploy
+from pathlib import Path
+import pytest
+import time
+import kfp
+import io
+
+
+def compile_testdata(name):
+    path = Path(__file__).parent / f"./testdata/kubeflow/{name}.yaml"
+    return nbproc.compile(path.open("rb"), "kubeflow")
+
+
+def fetch_status(deployment, max_polls=10, poll_sleep=10):
+    client = kfp.Client()
+
+    polls = 0
+    while polls < max_polls:
+        time.sleep(poll_sleep)
+        api_result = client.get_run(deployment.run_info.id)
+        if api_result.run.status is not None and not api_result.run.status == "Running":
+            return api_result.run.status
+
+        polls += 1
+
+    pytest.fail(f"Failed to fetch kubeflow status for run {deployment.run_info.id} after waiting for {max_polls*poll_sleep}s.")
+
+
+@pytest.mark.kubeflow
+def test_kubeflow_function_references():
+    """
+    Tests kubeflow execution for notebooks with functions defined in the
+    global scope that call other functions defined in the global scope.
+      see: https://github.com/SAME-Project/same-project/issues/69
+    """
+    compiled_path, root_file = compile_testdata("function_references")
+    deployment = deploy("kubeflow", compiled_path, root_file)
+    assert fetch_status(deployment) == "Success"
+
+
+@pytest.mark.kubeflow
+def test_kubeflow_imported_functions():
+    """
+    Tests kubeflow execution for notebooks with functions defined in the
+    global scope that use imported functions.
+      see: https://github.com/SAME-Project/same-project/issues/71
+    """
+    compiled_path, root_file = compile_testdata("imported_functions")
+    deployment = deploy("kubeflow", compiled_path, root_file)
+    assert fetch_status(deployment) == "Success"

--- a/test/backends/testdata/kubeflow/function_references.ipynb
+++ b/test/backends/testdata/kubeflow/function_references.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can inspect the output context in kubeflow to ensure this changes to '1'.\n",
+    "x = 0\n",
+    "\n",
+    "def a():\n",
+    "    global x\n",
+    "    x = 1\n",
+    "    \n",
+    "def b():\n",
+    "    a()\n",
+    "    \n",
+    "b()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/backends/testdata/kubeflow/function_references.yaml
+++ b/test/backends/testdata/kubeflow/function_references.yaml
@@ -1,0 +1,13 @@
+apiVersion: projectsame.io/v1alpha1
+metadata:
+  name: function_references
+  version: 0.0.1
+notebook:
+  name: "function_references"
+  path: function_references.ipynb
+environments:
+  default:
+    image_tag: library/python:3.9-slim-buster
+run:
+  name: "function_references"
+  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718

--- a/test/backends/testdata/kubeflow/imported_functions.ipynb
+++ b/test/backends/testdata/kubeflow/imported_functions.ipynb
@@ -1,0 +1,42 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We can inspect the output context in kubeflow to ensure this contains a JSON dump.\n",
+    "x = None\n",
+    "\n",
+    "import json\n",
+    "def a():\n",
+    "    global x\n",
+    "    x = json.dumps({ \"x\": 0 })\n",
+    "    \n",
+    "a()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/backends/testdata/kubeflow/imported_functions.yaml
+++ b/test/backends/testdata/kubeflow/imported_functions.yaml
@@ -1,0 +1,14 @@
+apiVersion: projectsame.io/v1alpha1
+metadata:
+  name: imported_functions
+  version: 0.0.1
+notebook:
+  name: "imported_functions"
+  path: imported_functions.ipynb
+environments:
+  default:
+    image_tag: library/python:3.9-slim-buster
+run:
+  name: "imported_functions"
+  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718
+

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -35,7 +35,7 @@ def run_before_and_after_tests():
     sys.modules.clear()
     sys.modules.update(original_sys_modules)
 
-@pytest.mark.skip("Skipping until we mock or create a live Kubeflow cluster")
+@pytest.mark.kubeflow
 def test_live_test_kubeflow(mocker, tmpdir, same_config):
     temp_dir_mock = mocker.patch.object(tempfile, "mkdtemp")
     temp_dir_mock.return_value = tmpdir
@@ -85,7 +85,7 @@ def test_live_test_aml(mocker, tmpdir, same_config):
     )
     assert result.exit_code == 0
 
-@pytest.mark.skip("Skipping until we mock or create a live Kubeflow cluster")
+@pytest.mark.kubeflow
 def test_kubeflow_same_program_run_with_secrets_e2e():
     multi_env_same_config_file_path = "test/testdata/multienv_notebook/same.yaml"
     same_file_path = Path(multi_env_same_config_file_path)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,13 @@ def pytest_addoption(parser):
         parser.addoption(f"--{name}", **opts)
 
 
+def pytest_configure(config):
+    for [name, _] in additional_flags:
+        config.addinivalue_line(
+            "markers", f"{name}: mark test to run only when --{name} flag is set"
+        )
+
+
 def pytest_collection_modifyitems(config, items):
     for [name, _] in additional_flags:
         if config.getoption(f"--{name}"):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+
+
+additional_flags = [
+    ["kubeflow", {
+        "action": "store_true",
+        "default": False,
+        "help": "run kubeflow backend tests, requires kubeflow installation",
+    }]
+]
+
+
+def pytest_addoption(parser):
+    for [name, opts] in additional_flags:
+        parser.addoption(f"--{name}", **opts)
+
+
+def pytest_collection_modifyitems(config, items):
+    for [name, _] in additional_flags:
+        if config.getoption(f"--{name}"):
+            continue  # don't skip if flag is set
+
+        skip = pytest.mark.skip(f"--{name} flag isn't set")
+        for item in items:
+            if name in item.keywords:
+                item.add_marker(skip)
+


### PR DESCRIPTION
See #69 and #71.

Adds kubeflow backend tests that can be run with `pytest --kubeflow`. Currently
they fail, as the kubeflow backend breaks when notebooks contain certain python
patterns (see the issues).

Also re-enables magic line parsing as some tests depend on it (there's an issue
with multiline comments that needs to be fixed - see https://github.com/SAME-Project/same-project/commit/8fb08e2354b)
