### PR TITLE
Add needs-ok-to-test label to all incoming pull requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,2 @@
+needs-ok-to-test:
+- "**/*"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/labeler@v2
+    - uses: actions/labeler@v4
       with:
         repo-token: ${{github.token}}
-        sync-labels: "needs-ok-to-test"
-        configuration-path: .github/workflows/labeler.yml


### PR DESCRIPTION
See #61.

The configuration for the labeller action is broken - this should add the
`needs-ok-to-test` label to any incoming PR that modifies any file (i.e all
incoming PRs).
