### PR TITLE
Allow spaces in same.yaml metadata name field

### DIFF
--- a/sameproject/same_config.py
+++ b/sameproject/same_config.py
@@ -27,7 +27,7 @@ class SameValidator(Validator):
         "metadata": {
             "type": "dict",
             "schema": {
-                "name": {"type": "string", "required": True, "regex": r"^[\d\w]+"},
+                "name": {"type": "string", "required": True, "regex": r"^[\d\w ]+"},
                 "version": {"type": "string", "required": True},
                 "labels": {"type": "list"},
                 "sha": {"type": "string"},

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -31,4 +31,3 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if name in item.keywords:
                 item.add_marker(skip)
-

--- a/test/testdata/conda_notebooks/same.yaml
+++ b/test/testdata/conda_notebooks/same.yaml
@@ -4,7 +4,7 @@ metadata:
   version: 0.0.53
 environments:
   default:
-    image_tag: library/python:3.9-slim-buster
+    image_tag: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:v1.5.0
 notebook:
   name: "Needs Conda"
   path: needs_conda.ipynb

--- a/test/testdata/conda_notebooks/same.yaml
+++ b/test/testdata/conda_notebooks/same.yaml
@@ -1,6 +1,6 @@
 apiVersion: sameproject.io/v1alpha1
 metadata:
-  name: Needs Conda
+  name: "Needs Conda"
   version: 0.0.53
 environments:
   default:


### PR DESCRIPTION
I'm not completely sure how metadata.name is intended to be used - if it's just
a label for the same config, then allowing spaces in names seems harmless.
