### PR TITLE
Fix magic line parsing in notebook processor

### DIFF
--- a/sameproject/backends/executor.py
+++ b/sameproject/backends/executor.py
@@ -37,6 +37,6 @@ def deploy(target: str, root_file_absolute_path: str, root_module_name: str, per
     if not persist_temp_files:
         sameproject.helpers.recursively_remove_dir(Path(root_file_absolute_path))
     else:
-        click.echo(f"Files persisted in: {Path(root_file_absolute_path).parent}")
+        click.echo(f"Files persisted in: {root_file_absolute_path}")
 
     return deploy_return

--- a/sameproject/mapping.py
+++ b/sameproject/mapping.py
@@ -1,4 +1,6 @@
 library_mapping = """
+cv2:opencv-python
+skimage:scikit-image
 AFQ:pyAFQ
 AG_fft_tools:agpy
 ANSI:pexpect

--- a/sameproject/program/compile/notebook_processing.py
+++ b/sameproject/program/compile/notebook_processing.py
@@ -95,7 +95,7 @@ We cannot continue because the following lines cannot be converted into standard
 { magic_lines_string }"""
         )
         # After logging.error, what's pythonic? Raising? I'm doing it, but curious.
-        raise SyntaxError
+        raise SyntaxError(f"Magic lines are not supported:\n{magic_lines_string}")
 
     for k in return_steps:
         # If we want to do it just by code block, uncomment the below

--- a/sameproject/templates/kubeflow/step.jinja
+++ b/sameproject/templates/kubeflow/step.jinja
@@ -16,9 +16,7 @@ def component_fn(
     import os
 
     # User code for step, which we run in its own execution frame.
-    CODE = """
-{{ inner_code }}
-"""
+    CODE = dill.loads(urlsafe_b64decode("{{ inner_code }}"))
 
     # Helper function for posting metadata to mlflow.
     def post_metadata(json):

--- a/sameproject/templates/kubeflow/step.jinja
+++ b/sameproject/templates/kubeflow/step.jinja
@@ -29,6 +29,14 @@ def component_fn(
         except requests.exceptions.HTTPError as err:
             print(f"Error posting metadata: {err}")
 
+    # Helper function for checking if objects are dill-serialisable.
+    def is_dillable(obj):
+        try:
+            dill.dumps(obj)
+        except TypeError:
+            return False
+        return True
+
     # The context contains locally bound variables from the execution of
     # previous steps, which we inject into this step's namespace to simulate
     # the name resolution behaviour of Jupyter notebooks.
@@ -63,6 +71,10 @@ def component_fn(
     for k in context.keys():
         if k == "__builtins__":
             continue
+
+        if not is_dillable(context[k]):
+            continue
+
         output_context[k] = context[k]
     output_context_enc = urlsafe_b64encode(dill.dumps(output_context)).decode()
 

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -114,31 +114,3 @@ def test_kubeflow_same_program_run_with_secrets_e2e():
         ],
     )
     assert result.exit_code == 0
-
-    multi_env_same_config_file_path = "test/testdata/multienv_notebook/same.yaml"
-    same_file_path = Path(multi_env_same_config_file_path)
-    assert same_file_path.exists()
-
-    same_file_path_as_string = str(same_file_path.absolute())
-    runner = CliRunner()
-
-    result = runner.invoke(
-        run,
-        [
-            "-f",
-            same_file_path_as_string,
-            "-t",
-            "kubeflow",
-            "--image-pull-secret-name",
-            "IMAGE_PULL_SECRET_NAME",
-            "--image-pull-secret-registry-uri",
-            "IMAGE_PULL_SECRET_REGISTRY_URI",
-            "--image-pull-secret-username",
-            "IMAGE_PULL_SECRET_USERNAME",
-            "--image-pull-secret-password",
-            "IMAGE_PULL_SECRET_PASSWORD",
-            "--image-pull-secret-email",
-            "IMAGE_PULL_SECRET_EMAIL",
-        ],
-    )
-    assert result.exit_code == 0

--- a/test/program/test_compile.py
+++ b/test/program/test_compile.py
@@ -1,0 +1,23 @@
+import pytest
+from sameproject.program.compile import notebook_processing as nbproc
+
+
+magic_line_testcases = [
+    ("bad_python_lines", "test/testdata/notebook_edge_cases/bad_python_lines.ipynb", True),
+    ("multiline_strings", "test/testdata/notebook_edge_cases/multiline_strings.ipynb", False),
+]
+
+
+@pytest.mark.parametrize("name, path, expect_err", magic_line_testcases)
+def test_magic_line_parsing(name, path, expect_err):
+    """
+    Tests magic line parsing in notebooks, with edge-cases like
+    multiline strings containing what appear to be multiline strings.
+    """
+    notebook_dict = nbproc.read_notebook(path)
+
+    if expect_err:
+        with pytest.raises(SyntaxError):
+            assert nbproc.get_steps(notebook_dict)
+    else:
+        assert nbproc.get_steps(notebook_dict)

--- a/test/testdata/notebook_edge_cases/multiline_strings.ipynb
+++ b/test/testdata/notebook_edge_cases/multiline_strings.ipynb
@@ -1,0 +1,39 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ca1739e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "multiline_str = \"\"\"\n",
+    "ls\n",
+    "looks like a magic line but should be ignored:\n",
+    "! pip install \"six\"\n",
+    "\"\"\""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
See #72.

We are currently splitting notebook code by line and checking each line to see
if it's magic (`!pip install "..."`, for instance). This fails if there are
multiline strings containing what look like magic lines. Fortunately `jupytext`
provides a python parser than can differentiate these out of the box.
