### PR TITLE
Add explicit PR checkout to github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
@@ -92,6 +93,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+          ref: ${{ github.event.pull_request.head.sha }}
       # AZURE SECRET BLOB contains variables for connecting to AML. Specifically:
       # export AML_SP_NAME="xxxx"
       # export AML_SP_APP_ID="<UID>"


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

fixes https://github.com/SAME-Project/same-project/issues/61#event-6311428443

- add missing explicit PR checkout to run the workflow against the pull request branch instead of the base branch

Based on [Keeping your GitHub Actions and workflows secure blog post](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/), explicit PR checkout is insecure when running against untrusted code. However, with the condition to run only if `ok-to-test` label exists, this does remediate the issue (which is also stated in the blogpost).