### PR TITLE
Checkout head of PR explicitly in build/test github jobs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,8 +15,10 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           submodules: recursive
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -89,8 +91,10 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           submodules: recursive
       # AZURE SECRET BLOB contains variables for connecting to AML. Specifically:
       # export AML_SP_NAME="xxxx"


### PR DESCRIPTION
See #61.

Explicitly checks out the PR head, as otherwise the build/test steps run on the
base branch which doesn't contain any changes.
