### PR TITLE
Fix context serialisation with dump_session and test multistep notebooks on kubeflow

### DIFF
--- a/sameproject/templates/kubeflow/root.jinja
+++ b/sameproject/templates/kubeflow/root.jinja
@@ -65,12 +65,11 @@ def create_context_file(
 	context_string,
 	output_context_path: OutputPath(str),
 ):
-	from pathlib import Path as __Path
-
-	__p = __Path(output_context_path)
-	with __p.open("w+") as __file_handle:
-		__file_handle.write(context_string)
-
+	exec(f"""
+import dill
+dill.dump_session("{output_context_path}")
+""")
+	
 
 create_context_file_component = kfp.components.create_component_from_func(
 	func=create_context_file,

--- a/sameproject/templates/kubeflow/step.jinja
+++ b/sameproject/templates/kubeflow/step.jinja
@@ -15,9 +15,6 @@ def component_fn(
     import dill
     import os
 
-    # User code for step, which we run in its own execution frame.
-    CODE = dill.loads(urlsafe_b64decode("{{ inner_code }}"))
-
     # Helper function for posting metadata to mlflow.
     def post_metadata(json):
         if metadata_url == "":
@@ -29,66 +26,54 @@ def component_fn(
         except requests.exceptions.HTTPError as err:
             print(f"Error posting metadata: {err}")
 
-    # Helper function for checking if objects are dill-serialisable.
-    def is_dillable(obj):
-        try:
-            dill.dumps(obj)
-        except TypeError:
-            return False
-        return True
-
-    # The context contains locally bound variables from the execution of
-    # previous steps, which we inject into this step's namespace to simulate
-    # the name resolution behaviour of Jupyter notebooks.
-    context_enc = "gAR9lC4="
-    if input_context_path is not None:
-        with Path(input_context_path).open("r") as reader:
-            context_enc = reader.read()
-    context = dill.loads(urlsafe_b64decode(context_enc))
-
-    # Post pre-run metadata to mlflow.
-    run_info = dill.loads(urlsafe_b64decode(run_info))
-    post_metadata({
-        "experiment_id": run_info["experiment_id"],
-        "run_id": run_info["run_id"],
-        "step_id": "{{ name }}",
-        "metadata_type": "input",
-        "metadata_value": context_enc,
-        "metadata_time": datetime.datetime.now().isoformat(),
-    })
-
     # Move to writable directory as user might want to do file IO.
     # TODO: won't persist across steps, might need support in SDK?
     os.chdir(tempfile.mkdtemp())
 
-    # Runs the user code in a new execution frame with locals() and globals()
-    # both set to the given context. This imitates execution in a module block.
-    exec(CODE, context)
+    # Load information about the current experiment run:
+    run_info = dill.loads(urlsafe_b64decode(run_info))
 
-    # Serialises the resulting context for the next step. The '__builtins__'
-    # key is automatically injected by exec(...), so no need to keep it.
-    output_context = {}
-    for k in context.keys():
-        if k == "__builtins__":
-            continue
+    # Post session context to mlflow.
+    if input_context_path is not None:
+        with Path(input_context_path).open("rb") as reader:
+            context = urlsafe_b64encode(reader.read())
+            post_metadata({
+                "experiment_id": run_info["experiment_id"],
+                "run_id": run_info["run_id"],
+                "step_id": "{{ name }}",
+                "metadata_type": "input",
+                "metadata_value": context,
+                "metadata_time": datetime.datetime.now().isoformat(),
+            })
 
-        if not is_dillable(context[k]):
-            continue
+    # User code for step, which we run in its own execution frame.
+    user_code = f"""
+import dill
 
-        output_context[k] = context[k]
-    output_context_enc = urlsafe_b64encode(dill.dumps(output_context)).decode()
+# Load session context into global namespace:
+if "{input_context_path}" != "None":
+    dill.load_session("{input_context_path}")
 
-    # Write resulting context to the output file.
-    with Path(output_context_path).open("w+") as writer:
-        writer.write(output_context_enc)
+{dill.loads(urlsafe_b64decode("{{ inner_code }}"))}
 
-    # Post post-run metadata to mlflow.
-    post_metadata({
-        "experiment_id": run_info["experiment_id"],
-        "run_id": run_info["run_id"],
-        "step_id": "{{ name }}",
-        "metadata_type": "output",
-        "metadata_value": output_context_enc,
-        "metadata_time": datetime.datetime.now().isoformat(),
-    })
+# Save new session context to disk for the next component:
+dill.dump_session("{output_context_path}")
+"""
+
+    # Runs the user code in a new execution frame. Context from the previous
+    # component in the run is loaded into the session dynamically, and we run
+    # with a single globals() namespace to simulate top-level execution.
+    exec(user_code, globals(), globals())
+
+    # Post new session context to mlflow:
+    with Path(output_context_path).open("rb") as reader:
+        context = urlsafe_b64encode(reader.read())
+        post_metadata({
+            "experiment_id": run_info["experiment_id"],
+            "run_id": run_info["run_id"],
+            "step_id": "{{ name }}",
+            "metadata_type": "output",
+            "metadata_value": context,
+            "metadata_time": datetime.datetime.now().isoformat(),
+        })
 {% endautoescape %}

--- a/test/backends/testdata/kubeflow/multistep.ipynb
+++ b/test/backends/testdata/kubeflow/multistep.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "x = 0\n",
+    "def a(y):\n",
+    "    global x\n",
+    "    x = y\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tags": [
+     "same_step_1"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "a(1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "tags": [
+     "same_step_2"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "y = json.dumps(x)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/backends/testdata/kubeflow/multistep.yaml
+++ b/test/backends/testdata/kubeflow/multistep.yaml
@@ -1,0 +1,15 @@
+apiVersion: projectsame.io/v1alpha1
+metadata:
+  name: multistep
+  version: 0.0.1
+notebook:
+  name: "multistep"
+  path: multistep.ipynb
+environments:
+  default:
+    image_tag: library/python:3.9-slim-buster
+run:
+  name: "multistep"
+  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718
+
+


### PR DESCRIPTION
See #81.

Fixes a really thorny issue with context serialisation in the kubeflow backend
that was affecting multistep pipelines. Long discussion about the problem on
Slack, see https://sameproject.slack.com/archives/C01LNQJ3XHU/p1648654502210689.

Basically `dill` doesn't serialise namespaces by reference, so our approach of
running `exec(user_code, namespace)` breaks when there are functions defined in
the user code that reference the global `namespace`. On the other hand, it does
work when serialising modules, so this fix serialises the `__main__` module with
`dill.dump_session()` and `dill.load_session()`, and runs the user code directly in
the `__main__` module with `exec(user_code)`.

Other possibilities for a fix:
* Dump each kubeflow component's code into its own module, and serialise that
  module to avoid polluting `__main__`. Then we need to somehow inject the
  previous step's context into the module before running the code. I gave this
  a try but couldn't get it to work.
