### PR TITLE
Filter out unpickleable objects before serialising session in kubeflow backend

### DIFF
--- a/sameproject/templates/kubeflow/step.jinja
+++ b/sameproject/templates/kubeflow/step.jinja
@@ -56,6 +56,19 @@ if "{input_context_path}" != "None":
 
 {dill.loads(urlsafe_b64decode("{{ inner_code }}"))}
 
+# Remove anything from the global namespace that cannot be serialised.
+# TODO: this will include things like pandas dataframes, needs sdk support?
+_bad_keys = []
+_all_keys = list(globals().keys())
+for k in _all_keys:
+    try:
+        dill.dumps(globals()[k])
+    except TypeError:
+        _bad_keys.append(k)
+
+for k in _bad_keys:
+    del globals()[k]
+
 # Save new session context to disk for the next component:
 dill.dump_session("{output_context_path}")
 """

--- a/test/backends/test_kubeflow_backend.py
+++ b/test/backends/test_kubeflow_backend.py
@@ -79,7 +79,7 @@ def test_kubeflow_function_references():
 
     # Check that the output context has 'x' set to '1'.
     artifacts = fetch_output_contexts(deployment)
-    assert artifacts["component-fn-output_context"].x == 1
+    assert get_artifact_attr(artifacts["component-fn-output_context"], "x") == 1
 
 
 @pytest.mark.kubeflow
@@ -95,7 +95,7 @@ def test_kubeflow_imported_functions():
 
     # Check that the output context has a json dump in it.
     artifacts = fetch_output_contexts(deployment)
-    dump = json.loads(artifacts["component-fn-output_context"].x)
+    dump = json.loads(get_artifact_attr(artifacts["component-fn-output_context"], "x"))
     assert dump["x"] == 0
 
 

--- a/test/cli/test_run.py
+++ b/test/cli/test_run.py
@@ -35,6 +35,7 @@ def run_before_and_after_tests():
     sys.modules.clear()
     sys.modules.update(original_sys_modules)
 
+
 @pytest.mark.kubeflow
 def test_live_test_kubeflow(mocker, tmpdir, same_config):
     temp_dir_mock = mocker.patch.object(tempfile, "mkdtemp")


### PR DESCRIPTION
See #81.

While testing the roadsigns demo with multiple pipeline steps, some steps would
fail because they contain unpickleable objects like csv readers. This change
filters them out before dumping the session - might be worth logging the fields
that were filtered so users aren't surprised by this.
