### PR TITLE
Implement exploding variables for kubeflow backend when variables are not pickleable between steps.

### DIFF
--- a/sameproject/cli/run.py
+++ b/sameproject/cli/run.py
@@ -93,6 +93,8 @@ def run(
             raise ValueError(f"Missing values: {missing_values_string}")
 
     click.echo(f"File is: {same_file.name}")
-    compiled_same_file, root_module_name = nbproc.compile(same_file, target, secret_dict, aml_dict)
+    compile_dir, root_module_name = nbproc.compile(same_file, target, secret_dict, aml_dict)
+    if persist_temp_files:
+        click.echo(f"Compile artifacts persisted at: {compile_dir}")
     if not no_deploy:
-        sameproject.ops.backends.deploy(target, compiled_same_file, root_module_name, persist_temp_files)
+        sameproject.ops.backends.deploy(target, compile_dir, root_module_name, persist_temp_files)

--- a/sameproject/ops/explode.py
+++ b/sameproject/ops/explode.py
@@ -1,0 +1,304 @@
+import dill
+
+
+class BaseExplodingVariable:
+    """Base class for ExplodingVariable."""
+
+    def __setattr__(self, *args):
+        raise self.err
+
+    def __getattr__(self, attr):
+        raise self.err
+
+    def __delattr__(self, *args):
+        raise self.err
+
+    def __repr__(self, *args):
+        raise self.err
+
+    def __str__(self, *args):
+        raise self.err
+
+    def __unicode__(self, *args):
+        raise self.err
+
+    def __bytes__(self, *args):
+        raise self.err
+
+    def __format__(self, *args):
+        raise self.err
+
+    def __lt__(self, *args):
+        raise self.err
+
+    def __le__(self, *args):
+        raise self.err
+
+    def __eq__(self, *args):
+        raise self.err
+
+    def __ne__(self, *args):
+        raise self.err
+
+    def __gt__(self, *args):
+        raise self.err
+
+    def __ge__(self, *args):
+        raise self.err
+
+    def __hash__(self, *args):
+        raise self.err
+
+    def __bool__(self, *args):
+        raise self.err
+
+    def __dir__(self, *args):
+        raise self.err
+
+    def __get__(self, *args):
+        raise self.err
+
+    def __set__(self, *args):
+        raise self.err
+
+    def __delete__(self, *args):
+        raise self.err
+
+    def __set_name__(self, *args):
+        raise self.err
+
+    def __instancecheck__(self, *args):
+        raise self.err
+
+    def __subclasscheck__(self, *args):
+        raise self.err
+
+    def __call__(self, *args):
+        raise self.err
+
+    def __len__(self, *args):
+        raise self.err
+
+    def __length_hint__(self, *args):
+        raise self.err
+
+    def __getitem__(self, *args):
+        raise self.err
+
+    def __setitem__(self, *args):
+        raise self.err
+
+    def __delitem__(self, *args):
+        raise self.err
+
+    def __missing__(self, *args):
+        raise self.err
+
+    def __item__(self, *args):
+        raise self.err
+
+    def __reversed__(self, *args):
+        raise self.err
+
+    def __contains__(self, *args):
+        raise self.err
+
+    def __add__(self, *args):
+        raise self.err
+
+    def __sub__(self, *args):
+        raise self.err
+
+    def __mul__(self, *args):
+        raise self.err
+
+    def __matmul__(self, *args):
+        raise self.err
+
+    def __truediv__(self, *args):
+        raise self.err
+
+    def __floordiv__(self, *args):
+        raise self.err
+
+    def __mod__(self, *args):
+        raise self.err
+
+    def __divmod__(self, *args):
+        raise self.err
+
+    def __pow__(self, *args):
+        raise self.err
+
+    def __lshift__(self, *args):
+        raise self.err
+
+    def __rshift__(self, *args):
+        raise self.err
+
+    def __and__(self, *args):
+        raise self.err
+
+    def __xor__(self, *args):
+        raise self.err
+
+    def __or__(self, *args):
+        raise self.err
+
+    def __radd__(self, *args):
+        raise self.err
+
+    def __rsub__(self, *args):
+        raise self.err
+
+    def __rmul__(self, *args):
+        raise self.err
+
+    def __rmatmul__(self, *args):
+        raise self.err
+
+    def __rtruediv__(self, *args):
+        raise self.err
+
+    def __rfloordiv__(self, *args):
+        raise self.err
+
+    def __rmod__(self, *args):
+        raise self.err
+
+    def __rdivmod__(self, *args):
+        raise self.err
+
+    def __rpow__(self, *args):
+        raise self.err
+
+    def __rlshift__(self, *args):
+        raise self.err
+
+    def __rrshift__(self, *args):
+        raise self.err
+
+    def __rand__(self, *args):
+        raise self.err
+
+    def __rxor__(self, *args):
+        raise self.err
+
+    def __ror__(self, *args):
+        raise self.err
+
+    def __iadd__(self, *args):
+        raise self.err
+
+    def __isub__(self, *args):
+        raise self.err
+
+    def __imul__(self, *args):
+        raise self.err
+
+    def __imatmul__(self, *args):
+        raise self.err
+
+    def __itruediv__(self, *args):
+        raise self.err
+
+    def __ifloordiv__(self, *args):
+        raise self.err
+
+    def __imod__(self, *args):
+        raise self.err
+
+    def __ipow__(self, *args):
+        raise self.err
+
+    def __ilshift__(self, *args):
+        raise self.err
+
+    def __irshift__(self, *args):
+        raise self.err
+
+    def __iand__(self, *args):
+        raise self.err
+
+    def __ixor__(self, *args):
+        raise self.err
+
+    def __ior__(self, *args):
+        raise self.err
+
+    def __neg__(self, *args):
+        raise self.err
+
+    def __pos__(self, *args):
+        raise self.err
+
+    def __abs__(self, *args):
+        raise self.err
+
+    def __invert__(self, *args):
+        raise self.err
+
+    def __complex__(self, *args):
+        raise self.err
+
+    def __int__(self, *args):
+        raise self.err
+
+    def __float__(self, *args):
+        raise self.err
+
+    def __index__(self, *args):
+        raise self.err
+
+    def __round__(self, *args):
+        raise self.err
+
+    def __trunc__(self, *args):
+        raise self.err
+
+    def __floor__(self, *args):
+        raise self.err
+
+    def __ceil__(self, *args):
+        raise self.err
+
+    def __enter__(self, *args):
+        raise self.err
+
+    def __exit__(self, *args):
+        raise self.err
+
+
+class ExplodingVariable(BaseExplodingVariable):
+    """
+    Exploding variables raise an error when anything is done with them. They
+    are used to patch variables that cannot be serialised for various reasons
+    when passing context between containers for different SAME steps. The
+    error should inform the user of the reason the variable cannot be
+    serialised - dill might not support it, it may use too much memory etc.
+
+    Our approach is to patch all special methods on the class:
+    https://docs.python.org/3/reference/datamodel.html#special-method-names
+    """
+
+    def __init__(self, err):
+        self.err = err
+
+    # Patch to allow setting 'self.err' in the constructor.
+    def __setattr__(self, attr, value):
+        if attr == "err":
+            self.__dict__[attr] = value
+            return
+
+        super().__setattr__(self, attr, value)
+
+
+# Custom deserialiser for ExplodingVariable that bypasses the explosion.
+def deserialise(err):
+    return ExplodingVariable(err)
+
+
+# Custom serialiser for ExplodingVariable that bypasses the explosion.
+@dill.register(ExplodingVariable)
+def serialise(pickler, obj):
+    pickler.save_reduce(deserialise, (obj.err,), obj=obj)

--- a/sameproject/ops/kubeflow/render.py
+++ b/sameproject/ops/kubeflow/render.py
@@ -10,6 +10,7 @@ import os
 
 from sameproject.data.step import Step
 from sameproject.ops import helpers
+import sameproject.ops.explode
 
 
 kubeflow_run_info_template = "run_info.jinja"
@@ -178,10 +179,14 @@ def _build_root_file(env: Environment, all_steps: list, same_config: dict) -> st
 
 
 def _build_step_file(env: Environment, step: Step) -> str:
+    with open(sameproject.ops.explode.__file__, "r") as f:
+        explode_code = f.read()
+
     step_contract = {
         "name": step.name,
         "unique_step_name": step.unique_step_name,
-        "inner_code": urlsafe_b64encode(dill.dumps(step.code)).decode()
+        "user_code": urlsafe_b64encode(bytes(step.code, "utf-8")).decode(),
+        "explode_code": urlsafe_b64encode(bytes(explode_code, "utf-8")).decode(),
     }
 
     return env.get_template(kubeflow_step_template).render(step_contract)

--- a/sameproject/ops/kubeflow/root.jinja
+++ b/sameproject/ops/kubeflow/root.jinja
@@ -29,8 +29,7 @@ run_info_comp = kfp.components.create_component_from_func(
     packages_to_install=[
         "dill",
         "requests",
-        "mlflow==1.17.0",
-        "boto3==1.17.79",
+        "pympler==1.0.1",
         {{ step.package_string }} # TODO: make this a loop
     ],
 )

--- a/sameproject/ops/kubeflow/step.jinja
+++ b/sameproject/ops/kubeflow/step.jinja
@@ -53,24 +53,26 @@ def {{ unique_step_name }}_fn(
     user_code = f"""
 import dill
 
+# Load the exploding variables module:
+{urlsafe_b64decode("{{ explode_code }}").decode()}
+
 # Load session context into global namespace:
 if { len(input_context) } > 0:
     dill.load_session("{ input_context_path }")
 
-{dill.loads(urlsafe_b64decode("{{ inner_code }}"))}
+# Run the user's notebook code:
+{urlsafe_b64decode("{{ user_code }}").decode()}
 
-# Remove anything from the global namespace that cannot be serialised.
-# TODO: this will include things like pandas dataframes, needs sdk support?
-_bad_keys = []
+# Various types of serialisation failures we'd like to inform the user of:
+def cannot_pickle_msg(k):
+    return f"Variable '" + k +"' was defined in previous steps, but is unusable as it cannot be pickled."
+
+# Replace unserialisable variables with exploding variables so that the user
+# knows why they cannot use them in future steps:
 _all_keys = list(globals().keys())
 for k in _all_keys:
-    try:
-        dill.dumps(globals()[k])
-    except TypeError:
-        _bad_keys.append(k)
-
-for k in _bad_keys:
-    del globals()[k]
+    if not dill.pickles(globals()[k], safe=True):
+        globals()[k] = ExplodingVariable(Exception(cannot_pickle_msg(k)))
 
 # Save new session context to disk for the next component:
 dill.dump_session("{output_context_path}")

--- a/test/backends/testdata/kubeflow/exploding_variables.ipynb
+++ b/test/backends/testdata/kubeflow/exploding_variables.ipynb
@@ -1,0 +1,35 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generators cannot be pickled, so this should become an exploding variable.\n",
+    "x=(i*i for i in range(10))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/backends/testdata/kubeflow/exploding_variables.yaml
+++ b/test/backends/testdata/kubeflow/exploding_variables.yaml
@@ -1,0 +1,13 @@
+apiVersion: projectsame.io/v1alpha1
+metadata:
+  name: exploding_variables
+  version: 0.0.1
+notebook:
+  name: "exploding_variables"
+  path: exploding_variables.ipynb
+environments:
+  default:
+    image_tag: library/python:3.9-slim-buster
+run:
+  name: "exploding_variables"
+  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718

--- a/test/ops/test_explode.py
+++ b/test/ops/test_explode.py
@@ -1,0 +1,96 @@
+from sameproject.ops.explode import ExplodingVariable
+import pytest
+import dill
+
+
+class ExplodingException(Exception):
+    pass
+
+
+@pytest.fixture
+def exploder():
+    return ExplodingVariable(ExplodingException())
+
+
+def test_explode_can_pickle(exploder):
+    pickled_exploder = dill.dumps(exploder)
+    exploder = dill.loads(pickled_exploder)
+
+    # Should contain the same error after deserialising:
+    with pytest.raises(ExplodingException):
+        print(exploder)
+
+
+def test_explode_string(exploder):
+    with pytest.raises(ExplodingException):
+        f"{exploder}"
+
+    with pytest.raises(ExplodingException):
+        print(exploder)
+
+    with pytest.raises(ExplodingException):
+        repr(exploder)
+
+
+def test_explode_numeric(exploder):
+    with pytest.raises(ExplodingException):
+        exploder + 1
+
+    with pytest.raises(ExplodingException):
+        exploder += 1
+
+    with pytest.raises(ExplodingException):
+        -exploder
+
+    with pytest.raises(ExplodingException):
+        abs(exploder)
+
+
+def test_explode_bool(exploder):
+    with pytest.raises(ExplodingException):
+        exploder >> 4
+
+    with pytest.raises(ExplodingException):
+        exploder & exploder
+
+    with pytest.raises(ExplodingException):
+        exploder | exploder
+
+    with pytest.raises(ExplodingException):
+        exploder ^ exploder
+
+
+def test_explode_context(exploder):
+    with pytest.raises(ExplodingException):
+        with exploder:
+            True
+
+
+def test_explode_class(exploder):
+    with pytest.raises(ExplodingException):
+        exploder.random()
+
+
+def test_explode_list(exploder):
+    with pytest.raises(ExplodingException):
+        exploder[0]
+
+    with pytest.raises(ExplodingException):
+        0 in exploder
+
+    with pytest.raises(ExplodingException):
+        [0 for x in exploder]
+
+    with pytest.raises(ExplodingException):
+        sorted(exploder)
+
+    with pytest.raises(ExplodingException):
+        reversed(exploder)
+
+    with pytest.raises(ExplodingException):
+        len(exploder)
+
+
+def test_explode_function(exploder):
+    with pytest.raises(ExplodingException):
+        exploder()


### PR DESCRIPTION
Currently when serialising context between steps we delete anything that can't
be pickled. This change implements ExplodingVariables, which raise a given
exception whenever they are used, and uses them to replace unpickleable stuff
so that users at least know why their variable disappeared between steps.
