### PR TITLE
Add exploding variable for variables that use too much memory in kubeflow backend.

### DIFF
--- a/sameproject/data/config.py
+++ b/sameproject/data/config.py
@@ -31,6 +31,8 @@ schema = {
                 "environments": {
                     "type": "dict",
                     "must_have_default": True,
+                    "keysrules": {"type": "string"},  # TODO: env name regex
+                    "valuesrules": {"type": "string"},  # TODO: URI regex
                 },
             },
         },
@@ -81,7 +83,12 @@ class SameValidator(Validator):
     """Validator for SAME config files."""
 
     def _validate_must_have_default(self, constraint, field_name, values_needing_default):
-        """Constrains 'dict' types to have at least one field called 'default'."""
+        """
+        Constrains 'dict' types to have at least one field called 'default'.
+
+        The rule's arguments are validated against this schema:
+          { 'type': 'boolean' }
+        """
         if constraint and (values_needing_default is None or values_needing_default.get("default", None) is None):
             self._error(field_name, f"{field_name} does not contain a 'default' entry.")
 

--- a/sameproject/ops/kubeflow/render.py
+++ b/sameproject/ops/kubeflow/render.py
@@ -187,6 +187,7 @@ def _build_step_file(env: Environment, step: Step) -> str:
         "unique_step_name": step.unique_step_name,
         "user_code": urlsafe_b64encode(bytes(step.code, "utf-8")).decode(),
         "explode_code": urlsafe_b64encode(bytes(explode_code, "utf-8")).decode(),
+        "memory_limit": 50 * 2**20,  # 50MB
     }
 
     return env.get_template(kubeflow_step_template).render(step_contract)

--- a/sameproject/ops/kubeflow/step.jinja
+++ b/sameproject/ops/kubeflow/step.jinja
@@ -51,6 +51,7 @@ def {{ unique_step_name }}_fn(
 
     # User code for step, which we run in its own execution frame.
     user_code = f"""
+from pympler import asizeof
 import dill
 
 # Load the exploding variables module:
@@ -64,15 +65,24 @@ if { len(input_context) } > 0:
 {urlsafe_b64decode("{{ user_code }}").decode()}
 
 # Various types of serialisation failures we'd like to inform the user of:
-def cannot_pickle_msg(k):
-    return f"Variable '" + k +"' was defined in previous steps, but is unusable as it cannot be pickled."
+def _cannot_pickle_msg(k):
+    return "Variable '" + k +"' was defined in previous steps, but could not be serialised as it was not supported by 'dill'."
+
+def _too_large_msg(k, mem):
+    return "Variable '" + k + "' was defined in previous steps, but could not be serialised as it used too much memory (" + str(mem) + "B)."
 
 # Replace unserialisable variables with exploding variables so that the user
 # knows why they cannot use them in future steps:
 _all_keys = list(globals().keys())
-for k in _all_keys:
-    if not dill.pickles(globals()[k], safe=True):
-        globals()[k] = ExplodingVariable(Exception(cannot_pickle_msg(k)))
+for _k in _all_keys:
+    if not dill.pickles(globals()[_k], safe=True):
+        globals()[_k] = ExplodingVariable(Exception(_cannot_pickle_msg(_k)))
+        continue
+
+    _mem = asizeof.asizeof(globals()[_k])
+    if _mem >= {{ memory_limit }}:
+        globals()[_k] = ExplodingVariable(Exception(_too_large_msg(_k, _mem)))
+        continue
 
 # Save new session context to disk for the next component:
 dill.dump_session("{output_context_path}")

--- a/test/backends/test_kubeflow_backend.py
+++ b/test/backends/test_kubeflow_backend.py
@@ -73,9 +73,16 @@ def test_kubeflow_exploding_variables():
     deployment = deploy("kubeflow", compiled_path, root_file)
     assert fetch_status(deployment) == "Succeeded"
 
-    # Check that the generator 'x' was replaced with an exploding variable:
+    # Fetch variables.
     artifacts = fetch_output_contexts(deployment)
+
+    # Check that the generator 'x' was replaced with an exploding variable:
     x = get_artifact_attr(artifacts, 0, "x")
+    with pytest.raises(Exception):
+        next(x)  # boom - see ops/explode.py
+
+    # Check that the large 'y' was replaced with an exploding variable:
+    x = get_artifact_attr(artifacts, 0, "y")
     with pytest.raises(Exception):
         next(x)  # boom - see ops/explode.py
 

--- a/test/backends/test_kubeflow_backend.py
+++ b/test/backends/test_kubeflow_backend.py
@@ -67,7 +67,7 @@ def test_kubeflow_multistep():
 @pytest.mark.kubeflow
 def test_kubeflow_exploding_variables():
     """
-    Tests that unpickleable variables are replaced with exploding ones.
+    Tests that unserialisable variables are replaced with exploding ones.
     """
     compiled_path, root_file = compile_testdata("exploding_variables")
     deployment = deploy("kubeflow", compiled_path, root_file)

--- a/test/backends/testdata/kubeflow/exploding_variables.ipynb
+++ b/test/backends/testdata/kubeflow/exploding_variables.ipynb
@@ -7,7 +7,10 @@
    "outputs": [],
    "source": [
     "# Generators cannot be pickled, so this should become an exploding variable.\n",
-    "x=(i*i for i in range(10))"
+    "x=(i*i for i in range(10))\n",
+		"\n",
+		"# Large array of >50MB in size should become an exploding variable.\n",
+		"y=list(range(2000000))"
    ]
   }
  ],


### PR DESCRIPTION
Replaces variables that use too much memory (>50MB) with an exploding variable
to prevent things like large datasets and models from overloading the context
between SAME steps.
