### PR TITLE
Fix module serialisation bug in kubeflow backend.

### DIFF
--- a/sameproject/ops/kubeflow/render.py
+++ b/sameproject/ops/kubeflow/render.py
@@ -192,7 +192,7 @@ def _build_step_file(env: Environment, step: Step) -> str:
         "user_code": urlsafe_b64encode(bytes(step.code, "utf-8")).decode(),
         "explode_code": urlsafe_b64encode(bytes(explode_code, "utf-8")).decode(),
         "requirements_file": requirements_file,
-        "memory_limit": 50 * 2**20,  # 50MB
+        "memory_limit": 250 * 2**20,  # 250MB
     }
 
     return env.get_template(kubeflow_step_template).render(step_contract)

--- a/sameproject/ops/kubeflow/step.jinja
+++ b/sameproject/ops/kubeflow/step.jinja
@@ -86,14 +86,17 @@ def _too_large_msg(k, mem):
 # knows why they cannot use them in future steps:
 _all_keys = list(globals().keys())
 for _k in _all_keys:
-    if not dill.pickles(globals()[_k], safe=True):
-        globals()[_k] = ExplodingVariable(Exception(_cannot_pickle_msg(_k)))
-        continue
-
     _mem = asizeof.asizeof(globals()[_k])
     if _mem >= {{ memory_limit }}:
         globals()[_k] = ExplodingVariable(Exception(_too_large_msg(_k, _mem)))
         continue
+
+    if not dill.pickles(globals()[_k], safe=True):
+        try:
+            dill.dumps(globals()[_k])
+        except TypeError:
+            globals()[_k] = ExplodingVariable(Exception(_cannot_pickle_msg(_k)))
+            continue
 
 # Save new session context to disk for the next component:
 dill.dump_session("{output_context_path}")

--- a/test/backends/testdata/kubeflow/exploding_variables.yaml
+++ b/test/backends/testdata/kubeflow/exploding_variables.yaml
@@ -10,4 +10,3 @@ environments:
     image_tag: library/python:3.9-slim-buster
 run:
   name: "exploding_variables"
-  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718

--- a/test/backends/testdata/kubeflow/function_references.yaml
+++ b/test/backends/testdata/kubeflow/function_references.yaml
@@ -10,4 +10,3 @@ environments:
     image_tag: library/python:3.9-slim-buster
 run:
   name: "function_references"
-  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718

--- a/test/backends/testdata/kubeflow/multistep.yaml
+++ b/test/backends/testdata/kubeflow/multistep.yaml
@@ -10,6 +10,3 @@ environments:
     image_tag: library/python:3.9-slim-buster
 run:
   name: "multistep"
-  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718
-
-

--- a/test/backends/testdata/kubeflow/requirements_file.yaml
+++ b/test/backends/testdata/kubeflow/requirements_file.yaml
@@ -11,4 +11,3 @@ environments:
     image_tag: library/python:3.9-slim-buster
 run:
   name: "requirements_file"
-  sha: 24a95219b3fce8402561d6b713bb435d6d5d51f2132d3c32703df8562db5b718

--- a/test/backends/testdata/kubeflow/serialised_modules.ipynb
+++ b/test/backends/testdata/kubeflow/serialised_modules.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Things imported in one step should be accessible in other steps.\n",
+    "import base64\n",
+    "import base64 as b64\n",
+    "from base64 import urlsafe_b64encode as ub64e\n",
+		"\n",
+		"# Numpy is a problematic case for dill: \n",
+		"import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": [
+     "same_step_1"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "x = base64.urlsafe_b64encode(\"test\".encode())\n",
+    "y = b64.urlsafe_b64encode(\"test\".encode())\n",
+    "z = ub64e(\"test\".encode())\n",
+		"a = np.array([1,2,3])"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/test/backends/testdata/kubeflow/serialised_modules.yaml
+++ b/test/backends/testdata/kubeflow/serialised_modules.yaml
@@ -1,12 +1,12 @@
 apiVersion: projectsame.io/v1alpha1
 metadata:
-  name: imported_functions
+  name: serialised_modules
   version: 0.0.1
 notebook:
-  name: "imported_functions"
-  path: imported_functions.ipynb
+  name: "serialised_modules"
+  path: serialised_modules.ipynb
 environments:
   default:
     image_tag: library/python:3.9-slim-buster
 run:
-  name: "imported_functions"
+  name: "serialised_modules"


### PR DESCRIPTION
Fixes #130. Dill complains that it can't serialise `numpy`, but succeeds anyway
if you try. Going back to an old approach of attempting to serialise variables
and replacing the ones that `throw` with exploding variables as well as checking
`dill.pickles(...)`.
