### PR TITLE
Use google-github actions to authenticate with gcloud kubeflow cluster

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,10 +12,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: contains(github.event.pull_request.labels.*.name, "ok-to-test")
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.sha }}
@@ -35,37 +35,40 @@ jobs:
           poetry run flake8 **/*.py
   test:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: contains(github.event.pull_request.labels.*.name, "ok-to-test")
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
           submodules: recursive
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Download env variables
+      - name: Set env variables
         run: |
           echo "$AZURE_SECRET_BLOB" > ./.env.sh
         shell: bash
         env:
-          AZURE_SECRET_BLOB: ${{secrets.AZURE_SECRET_BLOB}}
+          AZURE_SECRET_BLOB: ${{ secrets.AZURE_SECRET_BLOB }}
       - name: Set up python
         uses: actions/setup-python@v2
         with:
           python-version: "3.10"
-      - name: Install dependencies
+      - name: Install python tools
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-      - name: Install packages
+      - name: Install dependencies
         run: |
           poetry install --no-root
-      - name: Authenticate to gcloud kubeflow cluster
-        run: |
-          mkdir -p $HOME/.kube
-          echo "${{ secrets.KUBEFLOW_V181_GCP_CONFIG }}" > $HOME/.kube/config
-          echo "${{ secrets.KUBEFLOW_V181_GCP_KEY }}" > $HOME/.kube/key
-          echo "KUBECONFIG=$HOME/.kube/config" >> $GITHUB_ENV
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$HOME/.kube/key" >> $GITHUB_ENV
+      - name: Authenticate with google cloud
+        uses: "google-github-actions/auth@v0"
+        with:
+          credentials_json: "${{ secrets.KUBEFLOW_V181_GCP_KEY }}"
+      - name: Fetch GKE test cluster credentials
+        uses: "google-github-actions/get-gke-credentials@v0"
+        with:
+          location: "northamerica-northeast1-b"
+          project_id: "same-project-kubeflow"
+          cluster_name: "same-kubeflow-v181"
       - name: Run tests
         run: |
           set -o pipefail


### PR DESCRIPTION
Rather than pasting in a kubeconfig and google service account token, which
seems to be rather flaky, we now use some google-github actions that can take
a service account key and generate the kubeconfig automatically.
