### PR TITLE
Move runtime options into backend packages and add support for custom validation.

### DIFF
--- a/sameproject/cli/run.py
+++ b/sameproject/cli/run.py
@@ -1,4 +1,4 @@
-from sameproject.ops.runtime_options import runtime_options, get_option_value
+from sameproject.ops.runtime_options import validate_options, runtime_options, get_option_value
 from sameproject.data.config import SameConfig
 from io import BufferedReader
 from pathlib import Path
@@ -52,12 +52,15 @@ def run(
     persist_temp_files: bool = False,  # TODO: remove this
 ):
     """Compiles and deploys a pipeline from a SAME config file."""
+    # Validate runtime options against the configured backend:
+    validate_options(target)
+
     # TODO: Make SAME config object immutable (frozen_box=True).
     config = SameConfig.from_yaml(same_file.read(), frozen_box=False)
     config = config.resolve(Path(same_file.name).parent)
     config = config.inject_runtime_options()
 
-    click.echo(f"File is: {same_file.name}")
+    click.echo(f"Loading SAME config: {same_file.name}")
     base_path, root_file = notebooks.compile(config, target)
     if not no_deploy:
         backends.deploy(target, base_path, root_file, config)

--- a/sameproject/ops/aml/__init__.py
+++ b/sameproject/ops/aml/__init__.py
@@ -1,2 +1,4 @@
 from .render import render
 from .deploy import deploy
+
+import sameproject.ops.aml.options

--- a/sameproject/ops/aml/options.py
+++ b/sameproject/ops/aml/options.py
@@ -1,0 +1,10 @@
+from sameproject.ops.runtime_options import register_option, required_for_backend
+
+# TODO: write help lines for each of these options
+register_option("aml_compute_name", "")
+register_option("aml_sp_password_value", "")
+register_option("aml_sp_tenant_id", "")
+register_option("aml_sp_app_id", "")
+register_option("workspace_subscription_id", "")
+register_option("workspace_resource_group", "")
+register_option("workspace_name", "")

--- a/sameproject/ops/functions/__init__.py
+++ b/sameproject/ops/functions/__init__.py
@@ -1,3 +1,5 @@
 from .provision import provision_orchestrator
 from .render import render
 from .deploy import deploy
+
+import sameproject.ops.functions.options

--- a/sameproject/ops/functions/options.py
+++ b/sameproject/ops/functions/options.py
@@ -1,0 +1,17 @@
+from sameproject.ops.runtime_options import register_option, required_for_backend
+
+register_option(
+    "functions_subscription_id",
+    "Azure subscription ID in which to provision backend functions.",
+    validator=required_for_backend("functions"),
+    schema={
+        "type": "string",
+        "regex": r"^[\d\w-]+",
+    },
+)
+
+register_option(
+    "functions_skip_provisioning",
+    "Skip provisioning of azure functions resources, to be used only if they already exist.",
+    type=bool,
+)

--- a/sameproject/ops/kubeflow/__init__.py
+++ b/sameproject/ops/kubeflow/__init__.py
@@ -1,2 +1,4 @@
 from .render import render
 from .deploy import deploy
+
+import sameproject.ops.kubeflow.options

--- a/sameproject/ops/kubeflow/options.py
+++ b/sameproject/ops/kubeflow/options.py
@@ -1,0 +1,26 @@
+from sameproject.ops.runtime_options import register_option, required_for_backend
+
+register_option(
+    "image_pull_secret_name",
+    "The name of the kubernetes secret to create for docker secrets.",
+)
+
+register_option(
+    "image_pull_secret_registry_uri",
+    "URI of private docker registry for private image pulls.",
+)
+
+register_option(
+    "image_pull_secret_username",
+    "Username for private docker registry for private image pulls.",
+)
+
+register_option(
+    "image_pull_secret_password",
+    "Password for private docker registry for private image pulls.",
+)
+
+register_option(
+    "image_pull_secret_email",
+    "Email address for private docker registry for private image pulls.",
+)

--- a/sameproject/ops/runtime_options.py
+++ b/sameproject/ops/runtime_options.py
@@ -1,3 +1,5 @@
+from typing import Any, Callable, List, Optional
+from cerberus import Validator
 from box import Box
 import click
 import os
@@ -9,7 +11,7 @@ import os
 _registry = {}
 
 
-def runtime_options(fn):
+def runtime_options(fn) -> Callable:
     """Returns a click decorator composing all registered runtime options."""
     return _compose_decorators(
         fn,
@@ -17,7 +19,7 @@ def runtime_options(fn):
     )
 
 
-def runtime_schema():
+def runtime_schema() -> dict:
     """Returns a cerberus schema for validating runtime options."""
     schema = {
         "type": "dict",
@@ -25,22 +27,26 @@ def runtime_schema():
     }
 
     for opt in list_options():
-        schema["schema"][opt] = {
-            "type": _get_cerberus_type(
-                _registry[opt].name,
-                _registry[opt].type
-            )
-        }
+        opt_schema = _registry[opt].schema
+        if opt_schema is None:
+            opt_schema = {
+                "nullable": True,
+                "type": _get_cerberus_type(
+                    _registry[opt].name,
+                    _registry[opt].type
+                )
+            }
+        schema["schema"][opt] = opt_schema
 
     return schema
 
 
-def list_options():
+def list_options() -> List[str]:
     """Returns the list of registered options."""
     return _registry.keys()
 
 
-def get_option_value(name):
+def get_option_value(name: str) -> Any:
     """Returns the current value of the option with the given name."""
     if name not in _registry:
         raise Exception(f"Option registry does not contain name '{name}'.")
@@ -48,7 +54,7 @@ def get_option_value(name):
     return _registry[name].value
 
 
-def get_option_decorator(name):
+def get_option_decorator(name: str) -> Callable:
     """Returns a click decorator for setting an option via the command-line."""
     if name not in _registry:
         raise Exception(f"Option registry does not contain name '{name}'.")
@@ -61,21 +67,54 @@ def get_option_decorator(name):
         callback=_registry[name].callback,
         is_flag=_registry[name].type == bool,
         expose_value=False,  # don't affect click method signatures
-        required=False,  # TODO: support required runtime options?
         is_eager=True,  # handle runtime options before other options
     )
 
 
-def _compose_decorators(fn, decorators):
+def validate_options(backend: str):
+    """
+    Raises if the runtime options are set incorrectly for the given backend.
+    Doing it with 'validator' functions allows us to have options that are
+    conditionally dependent on each other for a particular backend.
+    """
+    opts = {}
+    for name in list_options():
+        opts[name] = get_option_value(name)
+
+    validator = Validator({"values": runtime_schema()})
+    if not validator.validate({"values": opts}):
+        raise SyntaxError(f"One or more runtime options is invalid: {validator.errors}")
+
+    for name in list_options():
+        if _registry[name].validator is not None:
+            _registry[name].validator(backend, name, opts)
+
+
+def _compose_decorators(fn: Callable, decorators: List[Callable]) -> Callable:
     for decorator in decorators:
         fn = decorator(fn)
     return fn
 
 
-def _register_option(name: str, desc: str, type=str, flag=None, env=None):
+def _register_option(
+    name: str,
+    desc: str,
+    type: Any = str,
+    flag: Optional[str] = None,
+    env: Optional[str] = None,
+    schema: Optional[dict] = None,
+    validator: Callable[[str, str, dict], None] = None,
+):
     """
-    Registers an option with the given internal name, command-line flag and
-    environment variable.
+    Registers a runtime option with the given metadata.
+
+    :param name: The internal name used to refer to the option.
+    :param desc: A description of what the option is configuring.
+    :param type: The Python type of the option, e.g. 'str' or 'bool'.
+    :param flag: Command line flag used to set the option. Defaults to a kebab-case translation of 'name', e.g. 'my_opt' ==> '--my-opt'.
+    :param env: Environment variable used to set the option. Defaults to an upper-case translation of 'name', e.g. 'my_opt' ==> 'MY_OPT'.
+    :param schema: Cerberus schema used to validate the option once it's been set. Defaults to checking that the input matches 'type'.
+    :param validator: Function that receives the current backend, option name and bag of options and raises if the option has been set incorrectly.
     """
     if flag is None:
         flag = "--" + name.replace("_", "-")
@@ -94,11 +133,13 @@ def _register_option(name: str, desc: str, type=str, flag=None, env=None):
         "env": env,
         "type": type,
         "value": value,
+        "schema": schema,
+        "validator": validator,
         "callback": lambda ctx, param, value: setattr(_registry[name], "value", value),
     })
 
 
-def _get_cerberus_type(name, type):
+def _get_cerberus_type(name: str, type: Any) -> str:
     if type == str:
         return "string"
 

--- a/test/ops/test_runtime_options.py
+++ b/test/ops/test_runtime_options.py
@@ -1,0 +1,54 @@
+import sameproject.ops.runtime_options as opts
+import pytest
+
+
+# Cerberus schemas for testing validation:
+alphanum = {
+    "nullable": True,
+    "type": "string",
+    "regex": r"^[\d\w ]+",
+}
+dockertag = {
+    "nullable": True,
+    "type": "string",
+    "regex": ".*/.*"
+}
+
+
+# Validator functions for testing validation:
+def required_for_one(backend, name, opts):
+    if backend == "one":
+        if name not in opts or opts[name] is None:
+            raise Exception(f"Option '{name}' must be set for backend '{backend}'.")
+
+
+# Runtime options for testing schemas and validation:
+opts._register_option(
+    "test_one_alphanum", "",
+    type=str,
+    schema=alphanum,
+    validator=required_for_one,
+)
+opts._register_option(
+    "test_one_dockertag", "",
+    type=str,
+    schema=dockertag,
+)
+
+
+def test_runtime_validation():
+    # If we validate for backend 'two', then everything should be fine:
+    opts.validate_options("two")
+
+    # Validating for backend 'one' should raise, as we haven't set test_one_alphanum:
+    with pytest.raises(Exception):
+        opts.validate_options("one")
+
+    # Validating with an invalid value should raise a different exception:
+    opts._registry["test_one_alphanum"].value = "invalid$string"
+    with pytest.raises(SyntaxError):
+        opts.validate_options("one")
+
+    # Validating with an valid value should be fine:
+    opts._registry["test_one_alphanum"].value = "valid1234"
+    opts.validate_options("one")

--- a/test/ops/test_runtime_options.py
+++ b/test/ops/test_runtime_options.py
@@ -15,21 +15,14 @@ dockertag = {
 }
 
 
-# Validator functions for testing validation:
-def required_for_one(backend, name, opts):
-    if backend == "one":
-        if name not in opts or opts[name] is None:
-            raise Exception(f"Option '{name}' must be set for backend '{backend}'.")
-
-
 # Runtime options for testing schemas and validation:
-opts._register_option(
+opts.register_option(
     "test_one_alphanum", "",
     type=str,
     schema=alphanum,
-    validator=required_for_one,
+    validator=opts.required_for_backend("one"),
 )
-opts._register_option(
+opts.register_option(
     "test_one_dockertag", "",
     type=str,
     schema=dockertag,


### PR DESCRIPTION
See #156. I've added `options.py` files to each of the backends modules, with
the idea that all of the backend's runtime options should be specified and
configured there. For examples of how to use the `register_option(...)` API,
have a look at `sameproject/ops/functions/options.py` and
`test/ops/test_runtime_options.py`.
