### PR TITLE
Add fuzzer that tests 'same init' with randomised inputs.

### DIFF
--- a/sameproject/cli/init.py
+++ b/sameproject/cli/init.py
@@ -31,8 +31,6 @@ def init():
 
     nb_dict = read_notebook(nb_path)
     nb_name = str(nb_path).replace(".ipynb", "")
-    # if nb_name == "":
-    #     nb_name = "notebook"
     nb_name = click.prompt("Notebook name", default=nb_name, type=str)
 
     # Docker image data:
@@ -97,11 +95,6 @@ def init():
     # Add requirements if the user has configured one:
     if req is not None:
         same_config.notebook.requirements = str(req)
-
-    validator = SameValidator.get_validator()
-    if not validator.validate(same_config):
-        click.echo(f"One or more of the provided parameters was invalid: {validator.errors}", err=True)
-        exit(1)
 
     click.echo(f"About to write to {cfg.absolute()}:")
     click.echo()

--- a/test/cli/fuzzer.py
+++ b/test/cli/fuzzer.py
@@ -1,0 +1,37 @@
+from random import random, sample
+from typing import Mapping
+import pytest
+
+example_params = {
+    "abcdeABCDE": 16,
+    "_-": 8,
+    "'`\"": 2,
+    "(){}<>": 1,
+    "@#$%^&": 1,
+}
+
+
+# An example of how to use genstr(...):
+def test_genstr():
+    for _ in range(10):
+        print(genstr(example_params))
+
+
+def genstr(params: Mapping[str, int], dp: float = 0.05) -> str:
+    """
+    Generates a random string where each char is generated with probability
+    corresponding to its weight in the `params` mapping.
+        :param params: maps strings to their char's weights
+        :param p:      tunes the average length of the results
+    """
+    p = 0.1
+    res = ""
+    while random() > p:
+        res += _genchar(params)
+        p += dp
+
+    return res
+
+
+def _genchar(params: Mapping[str, int]) -> str:
+    return sample(sample(params.keys(), 1, counts=params.values())[0], 1)[0]

--- a/test/cli/test_init.py
+++ b/test/cli/test_init.py
@@ -1,0 +1,47 @@
+from sameproject.data.config import SameConfig
+from .fuzzer import genstr, example_params
+from sameproject.cli.init import init
+from click.testing import CliRunner
+from pathlib import Path
+import test.testdata
+import pytest
+
+
+def test_init():
+    for i in range(100):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            # Copy over a notebook for the test:
+            path = Path(test.testdata.__file__).parent / "features/singlestep/singlestep.ipynb"
+            data = path.read_text()
+            Path("a" + genstr(example_params) + ".ipynb").write_text(data)
+
+            # Run `same init` with randomly generated input data:
+            res = runner.invoke(init, input=_geninput())
+
+            # If an invariant is failed we print the test output for debugging:
+            output = f"Run output: \n{res.output}"
+
+            # `same init` should never exit with an unhandled exception.
+            assert res.exception is None or type(res.exception) is SystemExit, output
+
+            # If `same init` exits with code 1, then no config should be written.
+            if res.exit_code == 1:
+                assert not Path("same.yaml").exists(), output
+                continue
+
+            # If `same init` exits with code 0, then it should have written a config
+            # that is valid, and which can be run with `same run -f same.yaml`.
+            # TODO: actually call `same run` with a mock backend
+            path = Path("same.yaml")
+            assert path.exists(), output
+            try:
+                SameConfig.from_yaml(path.read_text())  # will validate the config
+            except Exception as err:
+                assert False, f"Invalid config:\n{err}\n\n{output}"
+
+
+def _geninput():
+    return "\n".join([
+        genstr(example_params) for _ in range(50)
+    ])


### PR DESCRIPTION
See #155. Currently `same init` doesn't do input validation properly, and will
happily write a broken `same.yaml` with bad inputs. This implements a simple
fuzzer that throws random data at `same init` and verifies that:
* there are no unhandled exceptions
* if the exit code is 1, no config is written
* if the exit code is 0, a valid config is written
